### PR TITLE
Check issue closed time more granualrly

### DIFF
--- a/lib/generateReleaseNotes.js
+++ b/lib/generateReleaseNotes.js
@@ -57,7 +57,7 @@ const getClosedIssues = async (octokit, owner, repo, since) => {
     const names = arr.map(obj => obj.name);
     labels = labels.concat(names);
   }
-  const minimalIssues = issues.map(({title, number, html_url, labels, user, pull_request = false}) => {
+  const minimalIssues = issues.map(({title, number, html_url, labels, user, closed_at, pull_request = false}) => {
     const labelTitles = labels.map(obj => obj.name);
     let minimalUser = null;
     if (user) {
@@ -66,10 +66,10 @@ const getClosedIssues = async (octokit, owner, repo, since) => {
         url: user.html_url
       };
     }
-    return {title, number, url: html_url, pull_request, user: minimalUser, labels: labelTitles};
+    return {title, number, url: html_url, pull_request, user: minimalUser, labels: labelTitles, closed_at};
   });
-  
-  const skippedIssues = await filter(minimalIssues, async ({pull_request, number, labels}) => {
+  const sinceDate = new Date(since);
+  const skippedIssues = await filter(minimalIssues, async ({pull_request, number, labels, closed_at}) => {
     let isMergedOrNotAPullRequest = true;
     if (pull_request) {
       try {
@@ -80,8 +80,10 @@ const getClosedIssues = async (octokit, owner, repo, since) => {
         }
       }
     }
+    const closedAt = new Date(closed_at);
 
-    return isMergedOrNotAPullRequest &&
+    return  closedAt > sinceDate &&
+            isMergedOrNotAPullRequest &&
            !labels.includes('duplicate') &&
            !labels.includes('wontfix/works for me')
     ;
@@ -97,8 +99,8 @@ const getClosedIssues = async (octokit, owner, repo, since) => {
 
 const generateReleaseNotes = async (octokit, owner, repo, sinceTagName, releaseTagName) => {
   debug(`Creating ${releaseTagName} release notes for ${owner}/${repo} at ${releaseTagName}`);
-  const sinceTag = await getTagInfo(octokit, owner, repo, sinceTagName);
-  const {dependencies, pullRequests, bugs, enhancements, remaining} = await getClosedIssues(octokit, owner, repo, sinceTag.date);
+  const { date: sinceTagDate } = await getTagInfo(octokit, owner, repo, sinceTagName);
+  const {dependencies, pullRequests, bugs, enhancements, remaining} = await getClosedIssues(octokit, owner, repo, sinceTagDate);
   const template = await fs.readFile(path.join(__dirname, '../templates/release-notes.hbs'));
   const hbs = Handlebars.compile(template.toString());
   const repositoryUrl = `https://github.com/${owner}/${repo}`;


### PR DESCRIPTION
The github API seems to lnly do mm/dd/yyyy, which causes problems with
something is merged on the same day the next tag is applied.  This adds
another more granular date check to skip issues with.

Refs #3