### PR TITLE
Pull tag through reference

### DIFF
--- a/lib/generateReleaseNotes.js
+++ b/lib/generateReleaseNotes.js
@@ -7,20 +7,22 @@ const { filter } = require('rsvp');
 const getTagInfo = async (octokit, owner, repo, tag) => {
   debug(`Getting info for the ${tag} tag in ${owner}/${repo}`);
   try {
-    const tags = await octokit.paginate(
-      octokit.repos.listTags,
-      { owner, repo, namespace: 'tags/' }
-    );
-
-    if (tags.length === 0) {
-      throw new Error(`${owner}:${repo} has no tags.`);
-    }
-    const ourTag = tags.find(obj => obj.name === tag);
-    if (!ourTag) {
+    const ref = await octokit.git.getRef({
+      owner,
+      repo,
+      ref: `tags/${tag}`,
+    });
+    if (!ref) {
       throw new Error(`${tag} does not exist in ${owner}:${repo}`);
     }
-    const { name, commit } = ourTag;
-    debug(`Found tag ${name} with hash ${commit.sha}`);
+    const ourTag = await octokit.git.getTag({
+      owner,
+      repo,
+      tag_sha: ref.data.object.sha
+    });
+    const commit = ourTag.data.object;
+
+    debug(`Found tag ${tag} with hash ${commit.sha}`);
   
     const tagCommit = await octokit.git.getCommit({
       owner,
@@ -29,9 +31,9 @@ const getTagInfo = async (octokit, owner, repo, tag) => {
     });
   
     const { date } = tagCommit.data.committer;
-    debug(`${name} is from ${date}`);
+    debug(`${tag} is from ${date}`);
   
-    return {name, date};
+    return {tag, date};
   } catch (e) {
     if (e.status === 404) {
       throw new Error('This repository does not exist.');


### PR DESCRIPTION
This limits API requests by only getting the reference and tag we need
instead of all tags in a repository.